### PR TITLE
Fix hashing and query ordering

### DIFF
--- a/Net/MulticastSourceAddress.cs
+++ b/Net/MulticastSourceAddress.cs
@@ -111,7 +111,7 @@ public class MulticastSourceAddress : NotifiableObject, IPersistable
 	/// <returns>A hash code for the current object.</returns>
 	public override int GetHashCode()
 	{
-		return GroupAddress?.GetHashCode() ?? 0 ^ Port.GetHashCode() ^ SourceAddress?.GetHashCode() ?? 0;
+	return (GroupAddress?.GetHashCode() ?? 0) ^ Port.GetHashCode() ^ (SourceAddress?.GetHashCode() ?? 0);
 	}
 
 	/// <summary>

--- a/Net/QueryString.cs
+++ b/Net/QueryString.cs
@@ -201,6 +201,7 @@ public class QueryString : Equatable<QueryString>, IEnumerable<KeyValuePair<stri
 		else
 		{
 			_compiledString = "?" + _queryString
+				.OrderBy(p => p.Key, StringComparer.InvariantCultureIgnoreCase)
 				.Select(p => (Encode(p.Key), Encode(p.Value)))
 				.ToQueryString();
 		}


### PR DESCRIPTION
## Summary
- correct hash computation for `MulticastSourceAddress`
- keep `QueryString` ordering stable by sorting keys

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435db6ebb083239c875876425d3d62