### PR TITLE
Add extra collection tests

### DIFF
--- a/Tests/Collections/CircularBufferExTests.cs
+++ b/Tests/Collections/CircularBufferExTests.cs
@@ -1,0 +1,49 @@
+namespace Ecng.Tests.Collections;
+
+[TestClass]
+public class CircularBufferExTests
+{
+	[TestMethod]
+	public void StatsComputation()
+	{
+		var buf = new CircularBufferEx<decimal>(3)
+		{
+			Operator = new Ecng.Common.DecimalOperator(),
+			MaxComparer = Comparer<decimal>.Default,
+			MinComparer = Comparer<decimal>.Default
+		};
+		buf.PushBack(1m);
+		buf.PushBack(2m);
+		buf.PushBack(3m);
+		buf.Sum.AssertEqual(6m);
+		buf.Max.Value.AssertEqual(3m);
+		buf.Min.Value.AssertEqual(1m);
+		buf.SumNoFirst.AssertEqual(5m);
+		buf.PushBack(4m);
+		buf.Sum.AssertEqual(9m);
+		buf.Max.Value.AssertEqual(4m);
+		buf.Min.Value.AssertEqual(2m);
+		buf.Clear();
+		buf.Sum.AssertEqual(0m);
+		buf.Max.HasValue.AssertFalse();
+		buf.Min.HasValue.AssertFalse();
+	}
+
+	[TestMethod]
+	public void CapacityReset()
+	{
+		var buf = new CircularBufferEx<int>(2)
+		{
+			Operator = new Ecng.Common.IntOperator(),
+			MaxComparer = Comparer<int>.Default,
+			MinComparer = Comparer<int>.Default
+		};
+		buf.PushBack(1);
+		buf.PushBack(2);
+		buf.Capacity = 3;
+		buf.PushBack(3);
+		buf.Sum.AssertEqual(3);
+		buf.Max.Value.AssertEqual(3);
+		buf.Min.Value.AssertEqual(3);
+	}
+}

--- a/Tests/Collections/CircularBufferTests.cs
+++ b/Tests/Collections/CircularBufferTests.cs
@@ -1,0 +1,56 @@
+namespace Ecng.Tests.Collections;
+
+[TestClass]
+public class CircularBufferTests
+{
+	[TestMethod]
+	public void AppendOverCapacity()
+	{
+		var buf = new CircularBuffer<int>(3);
+		buf.PushBack(1);
+		buf.PushBack(2);
+		buf.PushBack(3);
+		buf.IsFull.AssertTrue();
+		buf.PushBack(4);
+		buf.ToArray().SequenceEqual([2, 3, 4]).AssertTrue();
+	}
+
+	[TestMethod]
+	public void FrontBackPushPop()
+	{
+		var buf = new CircularBuffer<int>(2);
+		buf.PushBack(1);
+		buf.PushFront(0);
+		buf.Back().AssertEqual(1);
+		buf.Front().AssertEqual(0);
+		buf.PopBack();
+		buf.PopFront();
+		buf.IsEmpty.AssertTrue();
+	}
+
+	[TestMethod]
+	public void SegmentsEnumeration()
+	{
+		var buf = new CircularBuffer<int>(5);
+		buf.PushBack(1);
+		buf.PushBack(2);
+		buf.PushBack(3);
+		buf.PopFront();
+		buf.PushBack(4);
+		buf.PushBack(5);
+		buf.ToArray().SequenceEqual([2, 3, 4, 5]).AssertTrue();
+		var total = buf.ToArraySegments().Sum(s => s.Count);
+		total.AssertEqual(4);
+	}
+
+	[TestMethod]
+	public void ClearAndExceptions()
+	{
+		var buf = new CircularBuffer<int>(3);
+		buf.PushBack(1);
+		buf.PushBack(2);
+		buf.Clear();
+		buf.IsEmpty.AssertTrue();
+		Assert.ThrowsException<InvalidOperationException>(() => buf.PopBack());
+	}
+}

--- a/Tests/Collections/SynchronizedDictionaryTests.cs
+++ b/Tests/Collections/SynchronizedDictionaryTests.cs
@@ -1,0 +1,41 @@
+namespace Ecng.Tests.Collections;
+
+[TestClass]
+public class SynchronizedDictionaryTests
+{
+	[TestMethod]
+	public void BasicOperations()
+	{
+		var dict = new SynchronizedDictionary<int, string>();
+		dict.Add(1, "A");
+		dict[2] = "B";
+		dict.Count.AssertEqual(2);
+		dict.ContainsKey(1).AssertTrue();
+		dict[1].AssertEqual("A");
+		dict.Remove(2).AssertTrue();
+		dict.Count.AssertEqual(1);
+	}
+
+	[TestMethod]
+	public void TryGetAndClear()
+	{
+		var dict = new SynchronizedDictionary<int, string>();
+		dict.Add(1, "A");
+		dict.TryGetValue(1, out var v).AssertTrue();
+		v.AssertEqual("A");
+		dict.Clear();
+		dict.Count.AssertEqual(0);
+	}
+
+	[TestMethod]
+	public void Enumeration()
+	{
+		var dict = new SynchronizedDictionary<int, string>();
+		dict.Add(1, "A");
+		dict.Add(2, "B");
+		var items = dict.ToArray();
+		items.Length.AssertEqual(2);
+		items.Any(p => p.Key == 1 && p.Value == "A").AssertTrue();
+		items.Any(p => p.Key == 2 && p.Value == "B").AssertTrue();
+	}
+}

--- a/Tests/Collections/SynchronizedListTests.cs
+++ b/Tests/Collections/SynchronizedListTests.cs
@@ -1,0 +1,60 @@
+namespace Ecng.Tests.Collections;
+
+[TestClass]
+public class SynchronizedListTests
+{
+	[TestMethod]
+	public void RangeOperations()
+	{
+		var list = new SynchronizedList<int>();
+		list.AddRange(Enumerable.Range(1, 5));
+		list.Count.AssertEqual(5);
+		list.GetRange(1, 3).SequenceEqual([2, 3, 4]).AssertTrue();
+		list.RemoveRange([1, 2]);
+		list.ToArray().SequenceEqual([3, 4, 5]).AssertTrue();
+		list.RemoveRange(1, 2).AssertEqual(2);
+		list.ToArray().SequenceEqual([3]).AssertTrue();
+	}
+
+	[TestMethod]
+	public void Events()
+	{
+		var list = new SynchronizedList<int>();
+		var added = new List<int>();
+		var removed = new List<int>();
+		list.AddedRange += items => added.AddRange(items);
+		list.RemovedRange += items => removed.AddRange(items);
+		list.AddRange([1, 2, 3]);
+		added.SequenceEqual([1, 2, 3]).AssertTrue();
+		list.RemoveRange([1, 3]);
+		removed.SequenceEqual([1, 3]).AssertTrue();
+	}
+
+	[TestMethod]
+	public void NullCheck()
+	{
+		var list = new SynchronizedList<string> { CheckNullableItems = true };
+		Assert.ThrowsException<ArgumentNullException>(() => list.AddRange(["a", null]));
+	}
+
+	[TestMethod]
+	public void InsertAndIndexer()
+	{
+		var list = new SynchronizedList<int>();
+		list.AddRange([2, 3]);
+		list.Insert(0, 1);
+		list[0].AssertEqual(1);
+		list[2].AssertEqual(3);
+		list.IndexOf(3).AssertEqual(2);
+		list.RemoveAt(1);
+		list.ToArray().SequenceEqual([1, 3]).AssertTrue();
+	}
+
+	[TestMethod]
+	public void RemoveRangeBounds()
+	{
+		var list = new SynchronizedList<int>();
+		Assert.ThrowsException<ArgumentOutOfRangeException>(() => list.RemoveRange(-1, 1));
+		Assert.ThrowsException<ArgumentOutOfRangeException>(() => list.RemoveRange(0, 0));
+	}
+}

--- a/Tests/Collections/SynchronizedQueueTests.cs
+++ b/Tests/Collections/SynchronizedQueueTests.cs
@@ -1,0 +1,35 @@
+namespace Ecng.Tests.Collections;
+
+[TestClass]
+public class SynchronizedQueueTests
+{
+	[TestMethod]
+	public void BasicOperations()
+	{
+		var q = new SynchronizedQueue<int>();
+		q.Enqueue(1);
+		q.Enqueue(2);
+		q.Peek().AssertEqual(1);
+		q.Dequeue().AssertEqual(1);
+		q.Dequeue().AssertEqual(2);
+		q.Count.AssertEqual(0);
+	}
+
+	[TestMethod]
+	public void EmptyOperations()
+	{
+		var q = new SynchronizedQueue<int>();
+		Assert.ThrowsException<InvalidOperationException>(() => q.Dequeue());
+		Assert.ThrowsException<InvalidOperationException>(() => q.Peek());
+	}
+
+	[TestMethod]
+	public void UnsupportedMethods()
+	{
+		var q = new SynchronizedQueue<int>();
+		var list = (IList)q;
+		Assert.ThrowsException<NotSupportedException>(() => _ = list[0]);
+		Assert.ThrowsException<NotSupportedException>(() => list.Insert(0, 1));
+		Assert.ThrowsException<NotSupportedException>(() => list.RemoveAt(0));
+	}
+}

--- a/Tests/Collections/SynchronizedSetTests.cs
+++ b/Tests/Collections/SynchronizedSetTests.cs
@@ -1,0 +1,80 @@
+namespace Ecng.Tests.Collections;
+
+[TestClass]
+public class SynchronizedSetTests
+	{
+	[TestMethod]
+	public void IndexingAndDuplicates()
+	{
+		var set = new SynchronizedSet<int>(true);
+		set.AddRange([1, 2, 3]);
+		set[0].AssertEqual(1);
+		set.IndexOf(3).AssertEqual(2);
+		set.Remove(2).AssertTrue();
+		set.ThrowIfDuplicate = true;
+		Assert.ThrowsException<InvalidOperationException>(() => set.Add(1));
+		set.TryAdd(3).AssertFalse();
+	}
+
+	[TestMethod]
+	public void IndexingDisabled()
+	{
+		var set = new SynchronizedSet<int>();
+		set.Add(1);
+		Assert.ThrowsException<InvalidOperationException>(() => _ = set[0]);
+		Assert.ThrowsException<InvalidOperationException>(() => set.IndexOf(1));
+		Assert.ThrowsException<InvalidOperationException>(() => set.RemoveAt(0));
+	}
+
+	[TestMethod]
+	public void RangeEvents()
+	{
+		var set = new SynchronizedSet<int>();
+		var added = new List<int>();
+		var removed = new List<int>();
+		set.AddedRange += items => added.AddRange(items);
+		set.RemovedRange += items => removed.AddRange(items);
+		set.AddRange([1, 2, 3]);
+		added.SequenceEqual([1, 2, 3]).AssertTrue();
+		set.RemoveRange([1, 3]);
+		removed.SequenceEqual([1, 3]).AssertTrue();
+	}
+
+	[TestMethod]
+	public void UnionIntersectExceptSymmetric()
+	{
+		var set = new SynchronizedSet<int>();
+		set.AddRange([1, 2, 3]);
+		set.UnionWith([3, 4]);
+		set.OrderBy(t => t).SequenceEqual([1, 2, 3, 4]).AssertTrue();
+		set.IntersectWith([2, 4]);
+		set.OrderBy(t => t).SequenceEqual([2, 4]).AssertTrue();
+		set.ExceptWith([4]);
+		set.SequenceEqual([2]).AssertTrue();
+		set.SymmetricExceptWith([2, 3]);
+		set.OrderBy(t => t).SequenceEqual([3]).AssertTrue();
+	}
+
+	[TestMethod]
+	public void SetComparisons()
+	{
+		var set = new SynchronizedSet<int>();
+		set.AddRange([1, 2, 3]);
+		set.IsSubsetOf([0, 1, 2, 3, 4]).AssertTrue();
+		set.IsSupersetOf([1, 2]).AssertTrue();
+		set.IsProperSupersetOf([1, 2]).AssertTrue();
+		set.IsProperSubsetOf([1, 2, 3, 4]).AssertTrue();
+		set.Overlaps([3, 4, 5]).AssertTrue();
+		set.SetEquals([3, 2, 1]).AssertTrue();
+	}
+
+	[TestMethod]
+	public void IndexedRemoveRange()
+	{
+		var set = new SynchronizedSet<int>(true);
+		set.AddRange([1, 2, 3, 4]);
+		var removed = set.RemoveRange(1, 2);
+		removed.AssertEqual(2);
+		set.SequenceEqual([1, 4]).AssertTrue();
+	}
+	}

--- a/Tests/Collections/SynchronizedStackTests.cs
+++ b/Tests/Collections/SynchronizedStackTests.cs
@@ -1,0 +1,35 @@
+namespace Ecng.Tests.Collections;
+
+[TestClass]
+public class SynchronizedStackTests
+{
+	[TestMethod]
+	public void BasicOperations()
+	{
+		var st = new SynchronizedStack<int>();
+		st.Push(1);
+		st.Push(2);
+		st.Peek().AssertEqual(2);
+		st.Pop().AssertEqual(2);
+		st.Pop().AssertEqual(1);
+		st.Count.AssertEqual(0);
+	}
+
+	[TestMethod]
+	public void EmptyOperations()
+	{
+		var st = new SynchronizedStack<int>();
+		Assert.ThrowsException<InvalidOperationException>(() => st.Pop());
+		Assert.ThrowsException<InvalidOperationException>(() => st.Peek());
+	}
+
+	[TestMethod]
+	public void UnsupportedMethods()
+	{
+		var st = new SynchronizedStack<int>();
+		var list = (IList)st;
+		Assert.ThrowsException<NotSupportedException>(() => _ = list[0]);
+		Assert.ThrowsException<NotSupportedException>(() => list.Insert(0, 1));
+		Assert.ThrowsException<NotSupportedException>(() => list.RemoveAt(0));
+	}
+}


### PR DESCRIPTION
## Summary
- add comprehensive tests for collection classes
- split test classes by collection type
- remove previous combined test file
- expand `SynchronizedSet` tests with set operations and comparisons

## Testing
- `dotnet test --no-build -c Release` *(fails: `dotnet: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_68446b7cac008323968dc4ad63a9b604