### PR TITLE
Fix REST client utilities

### DIFF
--- a/Net.Clients/InMemoryRestApiClientCache.cs
+++ b/Net.Clients/InMemoryRestApiClientCache.cs
@@ -43,7 +43,20 @@ public class InMemoryRestApiClientCache : IRestApiClientCache
 		if (method is null)	throw new ArgumentNullException(nameof(method));
 		if (uri is null)	throw new ArgumentNullException(nameof(uri));
 
-		return (method, uri.To<string>().ToLowerInvariant(), null);
+		var builder = new UriBuilder(uri);
+		
+		if (!builder.Query.IsEmpty())
+		{
+			var sortedQuery = builder.Query.Substring(1)
+				.ParseUrl()
+				.ExcludeEmpty()
+				.OrderBy(p => p.key, StringComparer.InvariantCultureIgnoreCase)
+				.ToQueryString(true);
+
+			builder.Query = sortedQuery;
+		}
+
+		return (method, builder.Uri.ToString().ToLowerInvariant(), null);
 	}
 
 	/// <summary>

--- a/Net.Clients/RestBaseApiClient.cs
+++ b/Net.Clients/RestBaseApiClient.cs
@@ -394,7 +394,17 @@ public abstract class RestBaseApiClient(HttpMessageInvoker http, MediaTypeFormat
 	/// <param name="requestUri">The original request URI.</param>
 	/// <returns>The formatted URI string.</returns>
 	protected virtual string FormatRequestUri(string requestUri)
-		=> requestUri.Remove("Async").ToLowerInvariant();
+	{
+		if (requestUri.IsEmpty())
+			return requestUri;
+
+		const string suffix = "Async";
+
+		if (requestUri.EndsWith(suffix, StringComparison.Ordinal))
+			requestUri = requestUri.Substring(0, requestUri.Length - suffix.Length);
+
+		return requestUri.ToLowerInvariant();
+	}
 
 	/// <summary>
 	/// Converts the caller method information into a request URI.


### PR DESCRIPTION
## Summary
- fix `FormatRequestUri` to only trim `Async` suffix
- normalize query parameters when caching

## Testing
- `dotnet build Net.Clients/Net.Clients.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435dbfdc508323b71419d338e2a2f0