### PR TITLE
Add pre-commit hook to run tests

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Run unit tests before committing
+echo "Running unit tests..."
+
+dotnet test --no-build
+
+if [ $? -ne 0 ]; then
+  echo "Unit tests failed. Commit aborted."
+  exit 1
+fi
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ All projects within the ECNG System Framework are available as separate NuGet pa
 ## Contribution
 
 Contributions are welcome! If you have improvements or bug fixes, please feel free to fork the repository, make your changes, and submit a pull request.
+
+## Git Hooks
+
+The repository contains a pre-commit hook that runs the unit tests. To enable it, configure Git to use the hooks in the `.githooks` directory:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+After running the command above once, Git will execute the unit tests before each commit is created.


### PR DESCRIPTION
## Summary
- add `.githooks/pre-commit` script that runs `dotnet test`
- document how to enable the hook in README

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2abefa3c8323950c471627aa1c95